### PR TITLE
To new CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/ros:galactic-desktop
+FROM osrf/ros2:humble-desktop
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     unzip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --upgrade setuptools
-RUN pip install artefacts-client --extra-index-url https://d5cw4z7oemmfd.cloudfront.net/pep503/ -U
+RUN pip install artefacts-cli
 ENV DISPLAY=$DISPLAY
 WORKDIR turtle
 COPY artefacts.yaml .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/ros2:humble-desktop
+FROM osrf/ros:humble-desktop
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     unzip \

--- a/README.md
+++ b/README.md
@@ -1,63 +1,48 @@
 # Turtlesim Demo Project
 
-This project demonstrates how to run a basic ros2 end to end tests in simulation (here turtlesim).
+This project demonstrates how to run a basic ROS2 end-to-end test in simulation (here turtlesim).
+
+This demo runs either natively or in containers. Native runs work only on Ubuntu version compatible with the tested ROS2 Galactic and Humble versions. Container runs work on Linux, Darwin and Windows, with the later run in X11-compatible shells.
 
 ## Prerequisite
 
-You will need ROS2 galactic or humble installed.
+### Container for Linux/Darwin/Windows
 
-See instructions [here](https://docs.ros.org/en/humble/Installation.html)
+* Container system: Docker (Podman coming)
+* X11 window system, like XQuartz on Darwin and MobaXterm on Windows, configured to accept local network connections.
 
-## ROS2 tests
+### Native for supported Ubuntu
 
-You can run the tests with:
+This is tested and likely to work only on ROS2 Galactic/Humble Ubuntu systems.
+
+See instructions for example [here for Humble](https://docs.ros.org/en/humble/Installation.html)
+
+## Usage
+
+### Native for supported Ubuntu
+
+#### Preliminary: Direct test run
+
+You can run the tests directly with:
 
 ```
 launch_test launch_turtle.py
 ```
 
-As it is, the test will fail.
+The test should succeed. One way to make it fail for demo purpose is to, say, increment by 0 the turtle velocity, so it never reaches the edge expeced by the test case (see line 19 in `sample_node.py`).
 
-If you take a look at the code, you should be able to find what is wrong and make the test pass.
+#### Tests with Artefacts
 
+1. Create a free account and project on [Artefacts](https://app.artefacts.com)
+2. Install the Artefacts CLI: `pip3 install artefacts-cli`
+3. Edit the project name in `artefacts.yaml` to the name of your project in Artefacts (step 1).
+4. Run the tests with tracking enabled: `artefacts run basic_tests`
+5. Results and detail should shortly be available in your Artefacts dashboard.
 
-## Tests with ArtefactsCI
+### Container runs
 
+Runs should work out of the box, assuming complete X11 configuration:
 
-You can use one of the 2 options below.
+    artefacts run --in-package basic_tests
 
-### With local ROS2 install
-
-Additionally, you can use ArtefactsCI to keep track of your tests results.
-
-1. Create an account and project on ArtefactsCI
-
-2. Install the artefacts client
-
-```
-pip install artefacts-client --extra-index-url https://d5cw4z7oemmfd.cloudfront.net/pep503/ -U
-```
-
-2. Edit the project name in artefacts.yaml
-
-3. Run the tests with tracking enabled
-
-```
-artefacts run basic_tests
-```
-
-### Using Docker
-
-
-Tests on MacOS and Ubuntu 20 often require explictly authorizing access to X11:
-
-    [MacOS] xhost +127.0.0.1: This will start an X11 server if needed, and allow the container to connect.
-    [Ubuntu 20] xhost +local:docker
-
-Then build and run the docker container:
-
-```
-git clone git@github.com:art-e-fact/warp-client.git
-docker build -t turtle2 .
-docker run --env ARTEFACTS_KEY=[YOUR-API-KEY] --net host --env DISPLAY=$DISPLAY -v $(pwd):/turtle turtle2
-```
+This command will build any missing image before running a container. Please add `--repackage` to force a rebuild as needed.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project demonstrates how to run a basic ROS2 end-to-end test in simulation (here turtlesim).
 
-This demo runs either natively or in containers. Native runs work only on Ubuntu version compatible with the tested ROS2 Galactic and Humble versions. Container runs work on Linux, Darwin and Windows, with the later run in X11-compatible shells.
+This demo runs either natively or in containers. Native runs work only on Ubuntu version compatible with the tested ROS2 Humble versions (originally working with Galactic too). Container runs work on Linux, Darwin and Windows, with the later run in X11-compatible shells.
 
 ## Prerequisite
 
@@ -13,7 +13,7 @@ This demo runs either natively or in containers. Native runs work only on Ubuntu
 
 ### Native for supported Ubuntu
 
-This is tested and likely to work only on ROS2 Galactic/Humble Ubuntu systems.
+This is tested and likely to work only on ROS2 Humble Ubuntu systems.
 
 See instructions for example [here for Humble](https://docs.ros.org/en/humble/Installation.html)
 

--- a/artefacts.yaml
+++ b/artefacts.yaml
@@ -1,6 +1,6 @@
 version: 0.1.0
 
-project: test-project # Update to your project name
+project: artefacts-tests/example-turtlesim
 jobs:
   basic_tests: # Overall job name
     type: test

--- a/artefacts.yaml
+++ b/artefacts.yaml
@@ -6,7 +6,7 @@ jobs:
     type: test
     runtime:
       simulator: turtlesim
-      framework: ros2:galactic
+      framework: ros2:humble
     timeout: 2 #minutes
     scenarios:
       defaults: # Global to all scenarios, and overriden in specific scenarios.

--- a/sample_node.py
+++ b/sample_node.py
@@ -16,7 +16,7 @@ class TestListener(Node):
 
     def gt_callback(self, msg):
         vel_msg = Twist()
-        vel_msg.linear.y = 1.0
+        vel_msg.linear.x = 1.0
         self.velocity_publisher.publish(vel_msg)
         self.gt_pose = msg
         if self.gt_pose.x > 8:


### PR DESCRIPTION
This unit explains how to use the example with `artefacts run` and the new `artefacts run --in-package`.

It also changes a bit the approach:
* By default, the test passes, to start green.
* Example explanation on how to easily break the test, so a further run can show information on the dashboard.

Fine to get back to the original break-first version. Just found this way flowing better and didactic.

---
To give it a try:

```
cd example-turtlesim
git pull
git checkout to_new_cli
# pip install artefacts-cli>=0.6.15
artefacts run --in-package basic_tests
```

Should work on Linux and Darwin. Chances it works on Windows. Both Darwin and Windows assume a well configured X11---not so easy and will document more.